### PR TITLE
Eliminate a race condition crash in objectForKey

### DIFF
--- a/SSCache.m
+++ b/SSCache.m
@@ -105,6 +105,10 @@
 
 	// Load object from disk
 	object = [NSKeyedUnarchiver unarchiveObjectWithFile:path];
+	if (!object) {
+		// Object was removed from disk before we could read it
+		return nil;
+	}
 
 	// Store in cache
 	[_cache setObject:object forKey:key];


### PR DESCRIPTION
If another thread removes an object while we're in the process of
reading it from disk, a nil could be returned from NSKeyedUnarchiver.
Attempting to add this nil to the memory cache causes a crash.
