### PR TITLE
Make setObject:forKey: write to disk asynchronously

### DIFF
--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -177,7 +177,7 @@
 	// Save to memory cache
 	[self.cache setObject:object forKey:key];
 
-	dispatch_sync(self.diskQueue, ^{
+	dispatch_async(self.diskQueue, ^{
 		// Save to disk cache
 		[NSKeyedArchiver archiveRootObject:object toFile:[self _pathForKey:key]];
 	});


### PR DESCRIPTION
Is there a reason that `setObject:forKey:` doesn't save to the disk cache asynchronously [here](https://github.com/soffes/SAMCache/blob/master/SAMCache/SAMCache.m#L180)? The two other cache modifying methods (`remove` and `removeAllObjects`) both use `dispatch_async`.
