### PR TITLE
Minor fixes and imagePathForKey: addition to UIImageAdditions category

### DIFF
--- a/SAMCache/SAMCache.h
+++ b/SAMCache/SAMCache.h
@@ -111,7 +111,7 @@
 
  @param key The key of the object.
  */
-- (void)setObject:(id <NSCopying>)object forKey:(NSString *)key;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
 
 /**
  Remove an object from the cache.
@@ -164,7 +164,7 @@
 
  This method behaves the same as `setObject:forKey:`.
  */
-- (void)setObject:(id <NSCopying>)object forKeyedSubscript:(NSString *)key;
+- (void)setObject:(id <NSCoding>)object forKeyedSubscript:(NSString *)key;
 
 @end
 
@@ -174,6 +174,15 @@
 #import <UIKit/UIImage.h>
 
 @interface SAMCache (UIImageAdditions)
+
+/**
+ Returns the path to the raw image on disk associated with a given key.
+ 
+ @param key An object identifying the value.
+ 
+ @return Path to object on disk or `nil` if no object exists for the given `key`.
+ */
+- (NSString *)imagePathForKey:(NSString *)key;
 
 /**
  Synchronously get an image from the cache.

--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -165,7 +165,7 @@
 
 #pragma mark - Adding and Removing Cached Values
 
-- (void)setObject:(id <NSCopying>)object forKey:(NSString *)key {
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key {
 	NSParameterAssert(key);
 
 	// If there's no object, delete the key.
@@ -228,7 +228,7 @@
 }
 
 
-- (void)setObject:(id <NSCopying>)object forKeyedSubscript:(NSString *)key {
+- (void)setObject:(id <NSCoding>)object forKeyedSubscript:(NSString *)key {
 	NSParameterAssert(key);
 
 	[self setObject:object forKey:key];
@@ -265,6 +265,14 @@
 #import <UIKit/UIScreen.h>
 
 @implementation SAMCache (UIImageAdditions)
+
+- (NSString *)imagePathForKey:(NSString *)key {
+    NSParameterAssert(key);
+    
+	key = [[self class] _keyForImageKey:key];
+    NSString *path = [self pathForKey:key];
+    return path;
+}
 
 - (UIImage *)imageForKey:(NSString *)key {
 	NSParameterAssert(key);


### PR DESCRIPTION
- [x] Switching selector signatures to require objects to adhere to NSCoding instead of NSCopying (a typo in the library, perhaps?)
- [x] adding imagePathForKey: selector for getting disk path for raw images added using UIImageAdditions category selectors
