### PR TITLE
Disk-only cache writing and ability to flush memory cache

### DIFF
--- a/SAMCache/SAMCache.h
+++ b/SAMCache/SAMCache.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2011-2014 Sam Soffes. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface SAMCache : NSObject
 
@@ -133,9 +133,9 @@
  
  @param useDiskCacheOnly A value indicating whether or not to store the object in memory or only write object to disk cache location in an asynchronous fashion.
  
- @param withCompletion A callback block that indicates that all operations (synchronous and asynchronous) have been completed, with an indication of success for the disk wrigin operation.
+ @param completionBlock A callback block that indicates that all operations (synchronous and asynchronous) have been completed, with an indication of success for the disk wrigin operation.
  */
-- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key diskCacheOnly:(BOOL)useDiskCacheOnly withCompletion:(void (^)(BOOL didSave))block;
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key diskCacheOnly:(BOOL)useDiskCacheOnly withCompletion:(void (^)(BOOL didSave))completionBlock;
 
 /**
  Remove an object from the cache.
@@ -149,6 +149,11 @@
  */
 - (void)removeAllObjects;
 
+/**
+ Removes all cached objects from the memory cache. Does not remove disk-cache
+ entries.
+ */
+- (void)flushMemoryCache;
 
 ///-------------------------------
 /// @name Accessing the Disk Cache
@@ -195,7 +200,7 @@
 
 #if TARGET_OS_IPHONE
 
-#import <UIKit/UIImage.h>
+@import UIKit.UIImage;
 
 @interface SAMCache (UIImageAdditions)
 

--- a/Tests/SAMCacheTests.m
+++ b/Tests/SAMCacheTests.m
@@ -69,4 +69,40 @@
 	XCTAssertEqualObjects(@"subread", self.cache[@"subscriptRead"], @"Reading an object with a subscript");
 }
 
+- (void)testAddingToDiskCacheOnly {
+    [self.cache setObject:@42 forKey:@"answer" diskCacheOnly:YES];
+    
+    XCTAssertNil([self.cache.cache objectForKey:@"answer"]);
+    
+    XCTAssertEqualObjects(@42, [self.cache objectForKey:@"answer"], @"Reading from disk cache");
+    
+    XCTAssertNotNil([self.cache.cache objectForKey:@"answer"]);
+}
+
+- (void)testAddingToDiskCacheOnlyWithCallback {
+    XCTestExpectation *diskWriteExpectation = [self expectationWithDescription:@"object written to disk"];
+    
+    __weak SAMCacheTests *weakSelf = self;
+    
+    [weakSelf.cache setObject:@42 forKey:@"answer" diskCacheOnly:YES withCompletion:^(BOOL didSave) {
+        XCTAssert(didSave);
+        [diskWriteExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testFlushMemoryCache {
+    [self.cache setObject:@42 forKey:@"answer"];
+    XCTAssertEqualObjects(@42, [self.cache objectForKey:@"answer"], @"Reading from memory cache");
+    
+    [self.cache flushMemoryCache];
+    
+    XCTAssertNil([self.cache.cache objectForKey:@"answer"]);
+    
+    XCTAssertEqualObjects(@42, [self.cache objectForKey:@"answer"], @"Reading from disk cache");
+    
+    XCTAssertNotNil([self.cache.cache objectForKey:@"answer"]);
+}
+
 @end


### PR DESCRIPTION
Adding selectors to allow disk-only cache insertion; this is handy for pre-caching objects that may not be immediately used (for example, objects constructed from network responses).

This includes edits to update the comments on the 'setObject:' selectors for indicating the asynchronous nature of writing to the disk (as opposed to the synchronous insertion into the memory cache), along with an overloaded selector for specifying a callback block to listen for the completion of disk writing operations.

Also including an edit to expose a 'flushMemoryCache' selector that allows consumers of this cache to clear out the memory cache at will -- this does not remove the disk-cached items. This is useful for closing out memory usage in situations where it is unlikely that an end user will revisit the cached information in a short period of time, but still requires the ability to recall disk-cached information at a later point in time without re-populating the cache entirely.

Also includes test coverage.
