### PR TITLE
Added attribute to saved files to exclude them from backup

### DIFF
--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -179,7 +179,9 @@
 
 	dispatch_async(self.diskQueue, ^{
 		// Save to disk cache
-		[NSKeyedArchiver archiveRootObject:object toFile:[self _pathForKey:key]];
+		NSString *path = [self _pathForKey:key];
+		[NSKeyedArchiver archiveRootObject:object toFile:path];
+		[self _excludeFileFromBackup:[NSURL fileURLWithPath:path]];
 	});
 }
 
@@ -255,6 +257,18 @@
 
 	key = [self _sanitizeFileNameString: key];
 	return [self.directory stringByAppendingPathComponent:key];
+}
+
+- (BOOL)_excludeFileFromBackup:(NSURL *)fileUrl {
+	NSParameterAssert(fileUrl);
+	NSParameterAssert([[NSFileManager defaultManager] fileExistsAtPath:[fileUrl path]]);
+
+	NSError *error;
+	BOOL result = [fileUrl setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:&error];
+	if (error) {
+		NSLog(@"Failed to exclude file from backup: %@", error);
+	}
+	return result;
 }
 
 @end


### PR DESCRIPTION
This allows to use the documents folder for cache storage.

I would like to use the cache to store files that shoul be available offline, but if they are stored in the Caches folder the os might decide to remove those files if it's running low on disk space. Adding this attribute allows to use the Documents folder, thus preventing this. I don't think there is any drawback in adding the attribute if the file is in Caches, so it is always added.