### PR TITLE
Exclude files from backup fix

### DIFF
--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -97,6 +97,9 @@
 			if (error) {
 				NSLog(@"Failed to create caches directory: %@", error);
 			}
+			else {
+				[self _excludeFileFromBackup:[NSURL fileURLWithPath:self.directory]];
+			}
 		}
 	}
 	return self;
@@ -180,8 +183,9 @@
 	dispatch_async(self.diskQueue, ^{
 		// Save to disk cache
 		NSString *path = [self _pathForKey:key];
-		[NSKeyedArchiver archiveRootObject:object toFile:path];
-		[self _excludeFileFromBackup:[NSURL fileURLWithPath:path]];
+		if ([NSKeyedArchiver archiveRootObject:object toFile:path]) {
+			[self _excludeFileFromBackup:[NSURL fileURLWithPath:path]];
+		}
 	});
 }
 


### PR DESCRIPTION
Now only tries to exclude a file from backup if the archiving operation was successful. This prevents hitting the assert when it fails. Also, if the cache directory is created by SAMCache, the whole directory will be excluded from backup.