### PR TITLE
[fix] crash while loading bad image

### DIFF
--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -284,9 +284,10 @@
 
 	// Load object from disk
 	image = [UIImage imageWithContentsOfFile:path];
-
-	// Store in cache
-	[self.cache setObject:image forKey:key];
+    if (image) {
+        // Store in cache
+        [self.cache setObject:image forKey:key];
+    }
 
 	return image;
 }


### PR DESCRIPTION
Fixed crash for call-stack:
```
Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x2ac8ffef __exceptionPreprocess + 126
1  libobjc.A.dylib                0x39185c8b objc_exception_throw + 38
2  CoreFoundation                 0x2abe94a5 -[NSArray indexOfObjectIdenticalTo:]
3  CoreFoundation                 0x2abe9337 -[NSCache setObject:forKey:] + 42
4  Double                         0x0013427d -[SAMCache(UIImageAdditions) imageForKey:] (SAMCache.m:288)

. . .

-[NSCache setObject:forKey:cost:]: attempt to insert nil value (key: LKGameCenter_G:1283329383@2x.png)
```