### PR TITLE
Adding @3x postfix to the filename for scale 3.0

### DIFF
--- a/SAMCache/SAMCache.m
+++ b/SAMCache/SAMCache.m
@@ -375,7 +375,13 @@
 
 + (NSString *)_keyForImageKey:(NSString *)imageKey {
 	NSParameterAssert(imageKey);
-	NSString *scale = [[UIScreen mainScreen] scale] == 2.0f ? @"@2x" : @"";
+    CGFloat screenScale = [[UIScreen mainScreen] scale];
+    NSString *scale = @"@3x";
+    if(screenScale == 2.0f){
+        scale = @"@2x";
+    }else if(screenScale == 1.0f){
+        scale = @"";
+    }
 	return [imageKey stringByAppendingFormat:@"%@.png", scale];
 }
 


### PR DESCRIPTION
I had an issue that images cached on iPhone 6 plus lost correct scale 3.0 value when I loaded them from the cache. This commit solved the issue.